### PR TITLE
Added -UseBasicParsing

### DIFF
--- a/Functions/Update-GoogleDynamicDNS.ps1
+++ b/Functions/Update-GoogleDynamicDNS.ps1
@@ -95,7 +95,7 @@ Function Update-GoogleDynamicDNS {
   }
 
   if ($PSCmdlet.ShouldProcess("$subAndDomain","Adding IP")) {
-    $response = Invoke-WebRequest -uri $webRequestURI -Method Post -Body $params -Credential $credential 
+    $response = Invoke-WebRequest -uri $webRequestURI -UseBasicParsing -Method Post -Body $params -Credential $credential 
     $Result = $Response.Content
     $StatusCode = $Response.StatusCode
     switch ($Result) {


### PR DESCRIPTION
Added -UseBasicParsing.
This parameter is required when Internet Explorer is not installed on the computer.¹
Most Windows 10 machines will not have IE installed anymore, according to Microsoft²

1. https://docs.microsoft.com/de-de/powershell/module/Microsoft.PowerShell.Utility/Invoke-WebRequest?view=powershell-7.1&viewFallbackFrom=powershell-3.0
2. https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge/